### PR TITLE
Fix public facing typos.

### DIFF
--- a/CassiaWindowList@klangman/4.0/applet.js
+++ b/CassiaWindowList@klangman/4.0/applet.js
@@ -1549,7 +1549,7 @@ class WindowListButton {
     this._signalManager.connect(this.actor, "scroll-event", this._onScrollEvent, this);
     //this._signalManager.connect(this.actor, "notify::allocation", this._allocationChanged, this);
     this._signalManager.connect(this._settings, "changed::caption-type", this._updateLabel, this);
-    this._signalManager.connect(this._settings, "changed::display-caption-for-pined", this._updateLabel, this);
+    this._signalManager.connect(this._settings, "changed::display-caption-for-pinned", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::hide-caption-for-minimized", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::display-caption-for", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::show-ellipsis-for-groups", this._updateLabel, this);
@@ -2131,7 +2131,7 @@ class WindowListButton {
 
     let capSetting = this._settings.getValue("display-caption-for");
     let numSetting = this._settings.getValue("display-number");
-    let pinnedSetting = this._settings.getValue("display-caption-for-pined");
+    let pinnedSetting = this._settings.getValue("display-caption-for-pinned");
     let hideSetting = this._settings.getValue("hide-caption-for-minimized"); // For compatibility, the option name "hide-caption-for-minimized" was maintained, but now it has more then one possible value not only for minimized windows
     let style = this._settings.getValue("number-style");
     let numberType = this._settings.getValue("number-type");
@@ -4676,7 +4676,7 @@ class Workspace {
              if (this.iconSaturation!=100 && this.saturationType == SaturationType.Focused) {
                 this._currentFocus.updateIconSelection();
              }
-             let pinnedSetting = this._settings.getValue("display-caption-for-pined");
+             let pinnedSetting = this._settings.getValue("display-caption-for-pinned");
              let capSetting = this._settings.getValue("display-caption-for");
              if (pinnedSetting == PinnedLabel.Focused && capSetting === DisplayCaption.One) {
                 // Do we need to clear the label from the pooled window group

--- a/CassiaWindowList@klangman/4.0/settings-schema.json
+++ b/CassiaWindowList@klangman/4.0/settings-schema.json
@@ -37,7 +37,7 @@
       "type" : "section",
       "title" : "Window list button label settings",
       "dependency" : "group-windows<4",
-      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "show-ellipsis-for-groups", "label-width", "label-animation", "label-animation-time"]
+      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pinned", "hide-caption-for-minimized", "display-indicators", "show-ellipsis-for-groups", "label-width", "label-animation", "label-animation-time"]
     },
     "caption-number-settings" : {
       "type" : "section",
@@ -102,7 +102,7 @@
     "description": "Display labels for generic window list buttons",
     "tooltip": "Never: No windows get labels\nAlways: All windows get labels\nFocused: The window with focus will have a label\nOne per application pool: Only one label for a set of adjacent application windows"
   },
-  "display-caption-for-pined": {
+  "display-caption-for-pinned": {
     "type": "combobox",
     "default": 0,
     "options": {
@@ -112,7 +112,7 @@
       "Focused": 3
     },
     "description": "Display labels for pinned buttons",
-    "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned window that are running will have a label\nFocused: Only the pinned window with focus will have a label"
+    "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned windows that are running will have a label\nFocused: Only the pinned window with focus will have a label"
   },
   "hide-caption-for-minimized": {
     "type": "combobox",
@@ -144,7 +144,7 @@
     "default": 0,
     "dependency" : "group-windows<4",
     "description": "Show a vertical ellipsis (...) for grouped buttons",
-    "tooltip": "Prepend a vertical ellipsis unicode charter to the labels for grouped window-list buttons with more then one window. When on a vertical panel this option is not possible and the setting will be ignored."
+    "tooltip": "Prepend a vertical ellipsis unicode character to the labels for grouped window-list buttons with more then one window. When on a vertical panel this option is not possible and the setting will be ignored."
   },
   "trailing-pinned-behaviour": {
     "type": "switch",
@@ -219,7 +219,7 @@
     },
     "dependency" : "number-type>0",
     "description": "Display number",
-    "tooltip": "Controls when the number label is used. Smart means the the label will only appear when it is appropriate depending on the number label contents setting above. i.e. When there is two or more windows in a group, or when the windows workspace or monitor does not match the current one."
+    "tooltip": "Controls when the number label is used. Smart means the label will only appear when it is appropriate depending on the number label contents setting above. i.e. When there are two or more windows in a group, or when the windows workspace or monitor does not match the current one."
   },
   "number-style": {
     "type": "combobox",
@@ -245,7 +245,7 @@
       "Launcher": 4
     },
     "description": "Window list behavior style",
-    "tooltip": "Grouped: All windows for an application are managed by one button,\nPooled: All window list buttons for an application are pooled side by side,\nAutomatic: Windows are pooled, and then grouped when space is limited,\nOne to one: Each window gets their own button with no forced ordering,\nLauncher: Only pinned button are shown, behaves like a panel launcher."
+    "tooltip": "Grouped: All windows for an application are managed by one button,\nPooled: All window list buttons for an application are pooled side by side,\nAutomatic: Windows are pooled, and then grouped when space is limited,\nOne to one: Each window gets their own button with no forced ordering,\nLauncher: Only pinned buttons are shown, behaves like a panel launcher."
   },
   "display-pinned": {
     "type": "combobox",
@@ -264,7 +264,7 @@
     "default": false,
     "dependency" : "group-windows=4",
     "description": "Synchronize launcher buttons across all workspaces",
-    "tooltip": "If enabled, the number and order of launcher buttons on the panel will be synchronize across all workspaces."
+    "tooltip": "If enabled, the number and order of launcher buttons on the panel will be synchronized across all workspaces."
   },
   "show-windows-for-current-monitor": {
     "type": "switch",
@@ -345,21 +345,21 @@
     "default": false,
     "dependency" : "group-windows!=3",
     "description": "Sort grouped button thumbnail menu items",
-    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and the by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window-list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
+    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and then by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window-list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
   },
   "menu-all-windows-of-pool": {
     "type": "switch",
     "default": true,
     "dependency" : "group-windows=1",
     "description": "Show thumbnails for all windows of an application pool",
-    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather than just the selected window within the application pool"
   },
   "menu-all-windows-of-auto": {
     "type": "switch",
     "default": true,
     "dependency" : "group-windows=2",
     "description": "Show thumbnails for all windows of an application pool",
-    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather than just the selected window within the application pool"
   },
   "preview-timeout-show": {
     "type": "spinbutton",
@@ -779,7 +779,7 @@
     "type": "switch",
     "default": true,
     "description": "Use modifier(s) + ` hotkey to show hotkey hint bubbles",
-    "tooltip": "If enabled, The hotkey modifier(s) + ` will be registered for each unique modifier set defined in the hotkey list. Using these hotkeys will temporally show a hotkey hint bubble over the button icons."
+    "tooltip": "If enabled, The hotkey modifier(s) + ` will be registered for each unique modifier set defined in the hotkey list. Using these hotkeys will temporarily show a hotkey hint bubble over the button icons."
   },
 
   "hotkey-help" : {
@@ -905,7 +905,7 @@
        "Idle pinned buttons": 2,
        "Buttons for windows on other workspaces": 3,
        "Buttons for windows on other monitors": 4,
-       "All buttons excepted focused window": 5
+       "All buttons except the focused window": 5
     },
     "dependency": "icon-saturation!=100",
     "description": "Where to apply the icon color saturation",

--- a/CassiaWindowList@klangman/6.0/settings-schema.json
+++ b/CassiaWindowList@klangman/6.0/settings-schema.json
@@ -37,7 +37,7 @@
       "type" : "section",
       "title" : "Window list button label settings",
       "dependency" : "group-windows<4",
-      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pined", "hide-caption-for-minimized", "display-indicators", "show-ellipsis-for-groups", "label-width", "label-animation", "label-animation-time"]
+      "keys" : ["caption-type", "display-caption-for", "display-caption-for-pinned", "hide-caption-for-minimized", "display-indicators", "show-ellipsis-for-groups", "label-width", "label-animation", "label-animation-time"]
     },
     "caption-number-settings" : {
       "type" : "section",
@@ -102,7 +102,7 @@
     "description": "Display labels for generic window list buttons",
     "tooltip": "Never: No windows get labels\nAlways: All windows get labels\nFocused: The window with focus will have a label\nOne per application pool: Only one label for a set of adjacent application windows"
   },
-  "display-caption-for-pined": {
+  "display-caption-for-pinned": {
     "type": "combobox",
     "default": 0,
     "options": {
@@ -112,7 +112,7 @@
       "Focused": 3
     },
     "description": "Display labels for pinned buttons",
-    "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned window that are running will have a label\nFocused: Only the pinned window with focus will have a label"
+    "tooltip": "Never: No pinned windows will have a label\nAlways: All pinned windows will have labels\nRunning: Only pinned windows that are running will have a label\nFocused: Only the pinned window with focus will have a label"
   },
   "hide-caption-for-minimized": {
     "type": "combobox",
@@ -144,7 +144,7 @@
     "default": 0,
     "dependency" : "group-windows<4",
     "description": "Show a vertical ellipsis (...) for grouped buttons",
-    "tooltip": "Prepend a vertical ellipsis unicode charter to the labels for grouped window-list buttons with more then one window. When on a vertical panel this option is not possible and the setting will be ignored."
+    "tooltip": "Prepend a vertical ellipsis unicode character to the labels for grouped window-list buttons with more then one window. When on a vertical panel this option is not possible and the setting will be ignored."
   },
   "trailing-pinned-behaviour": {
     "type": "switch",
@@ -219,7 +219,7 @@
     },
     "dependency" : "number-type>0",
     "description": "Display number",
-    "tooltip": "Controls when the number label is used. Smart means the the label will only appear when it is appropriate depending on the number label contents setting above. i.e. When there is two or more windows in a group, or when the windows workspace or monitor does not match the current one."
+    "tooltip": "Controls when the number label is used. Smart means the label will only appear when it is appropriate depending on the number label contents setting above. i.e. When there are two or more windows in a group, or when the windows workspace or monitor does not match the current one."
   },
   "number-style": {
     "type": "combobox",
@@ -245,7 +245,7 @@
       "Launcher": 4
     },
     "description": "Window list behavior style",
-    "tooltip": "Grouped: All windows for an application are managed by one button,\nPooled: All window list buttons for an application are pooled side by side,\nAutomatic: Windows are pooled, and then grouped when space is limited,\nOne to one: Each window gets their own button with no forced ordering,\nLauncher: Only pinned button are shown, behaves like a panel launcher."
+    "tooltip": "Grouped: All windows for an application are managed by one button,\nPooled: All window list buttons for an application are pooled side by side,\nAutomatic: Windows are pooled, and then grouped when space is limited,\nOne to one: Each window gets their own button with no forced ordering,\nLauncher: Only pinned buttons are shown, behaves like a panel launcher."
   },
   "display-pinned": {
     "type": "combobox",
@@ -264,7 +264,7 @@
     "default": false,
     "dependency" : "group-windows=4",
     "description": "Synchronize launcher buttons across all workspaces",
-    "tooltip": "If enabled, the number and order of launcher buttons on the panel will be synchronize across all workspaces."
+    "tooltip": "If enabled, the number and order of launcher buttons on the panel will be synchronized across all workspaces."
   },
   "show-windows-for-current-monitor": {
     "type": "switch",
@@ -345,21 +345,21 @@
     "default": false,
     "dependency" : "group-windows!=3",
     "description": "Sort grouped button thumbnail menu items",
-    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and the by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window-list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
+    "tooltip": "If enabled, the thumbnail menu will be sorted first by workspace and then by monitor number for grouped buttons. Pooled windows can not be sorted since the order is the same as the order on the window-list panel. With this option enabled, the thumbnail menu drag-and-drop reordering feature will be disabled for grouped button thumbnail menus."
   },
   "menu-all-windows-of-pool": {
     "type": "switch",
     "default": true,
     "dependency" : "group-windows=1",
     "description": "Show thumbnails for all windows of an application pool",
-    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather than just the selected window within the application pool"
   },
   "menu-all-windows-of-auto": {
     "type": "switch",
     "default": true,
     "dependency" : "group-windows=2",
     "description": "Show thumbnails for all windows of an application pool",
-    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather then just the selected window within the application pool"
+    "tooltip": "If enabled, a popup menu will contain all the application windows in the application pool rather than just the selected window within the application pool"
   },
   "preview-timeout-show": {
     "type": "spinbutton",
@@ -779,7 +779,7 @@
     "type": "switch",
     "default": true,
     "description": "Use modifier(s) + ` hotkey to show hotkey hint bubbles",
-    "tooltip": "If enabled, The hotkey modifier(s) + ` will be registered for each unique modifier set defined in the hotkey list. Using these hotkeys will temporally show a hotkey hint bubble over the button icons."
+    "tooltip": "If enabled, The hotkey modifier(s) + ` will be registered for each unique modifier set defined in the hotkey list. Using these hotkeys will temporarily show a hotkey hint bubble over the button icons."
   },
 
   "hotkey-help" : {
@@ -900,7 +900,7 @@
        "Idle pinned buttons": 2,
        "Buttons for windows on other workspaces": 3,
        "Buttons for windows on other monitors": 4,
-       "All buttons excepted focused window": 5
+       "All buttons except the focused window": 5
     },
     "dependency": "icon-saturation!=100",
     "description": "Where to apply the icon color saturation",

--- a/CassiaWindowList@klangman/6.4/applet.js
+++ b/CassiaWindowList@klangman/6.4/applet.js
@@ -1527,7 +1527,7 @@ class WindowListButton {
     this._signalManager.connect(this.actor, "scroll-event", this._onScrollEvent, this);
     //this._signalManager.connect(this.actor, "notify::allocation", this._allocationChanged, this);
     this._signalManager.connect(this._settings, "changed::caption-type", this._updateLabel, this);
-    this._signalManager.connect(this._settings, "changed::display-caption-for-pined", this._updateLabel, this);
+    this._signalManager.connect(this._settings, "changed::display-caption-for-pinned", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::hide-caption-for-minimized", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::display-caption-for", this._updateLabel, this);
     this._signalManager.connect(this._settings, "changed::show-ellipsis-for-groups", this._updateLabel, this);
@@ -2109,7 +2109,7 @@ class WindowListButton {
 
     let capSetting = this._settings.getValue("display-caption-for");
     let numSetting = this._settings.getValue("display-number");
-    let pinnedSetting = this._settings.getValue("display-caption-for-pined");
+    let pinnedSetting = this._settings.getValue("display-caption-for-pinned");
     let hideSetting = this._settings.getValue("hide-caption-for-minimized"); // For compatibility, the option name "hide-caption-for-minimized" was maintained, but now it has more then one possible value not only for minimized windows
     let style = this._settings.getValue("number-style");
     let numberType = this._settings.getValue("number-type");
@@ -4645,7 +4645,7 @@ class Workspace {
              if (this.iconSaturation!=100 && this.saturationType == SaturationType.Focused) {
                 this._currentFocus.updateIconSelection();
              }
-             let pinnedSetting = this._settings.getValue("display-caption-for-pined");
+             let pinnedSetting = this._settings.getValue("display-caption-for-pinned");
              let capSetting = this._settings.getValue("display-caption-for");
              if (pinnedSetting == PinnedLabel.Focused && capSetting === DisplayCaption.One) {
                 // Do we need to clear the label from the pooled window group

--- a/CassiaWindowList@klangman/README.md
+++ b/CassiaWindowList@klangman/README.md
@@ -8,7 +8,7 @@ the "Download" tab from the cinnamon desktop settings and at the following URL:
 
 https://cinnamon-spices.linuxmint.com/applets/view/372
 
-If you like this applet, please go to the above link and "Like it" so that more people might learn of it's existence.
+If you like this applet, please go to the above link and "Like it" so that more people might learn of its existence.
 Also, the more likes it gets the more encouragement I'll have to continue working on it.
 Thanks!
 
@@ -24,7 +24,7 @@ The design goals are to:
 1. Allow you to declutter your window list when running many windows without having to do without button labels
 2. Keyboard hot-keys to switch to specific windows so you don't have to reach for the mouse so often
 3. Allow you to make full use of your mouse buttons to interact with the window list
-4. A panel launcher that can activate existing windows rather then unconditionally launching new ones
+4. A panel launcher that can activate existing windows rather than unconditionally launching new ones
 
 ## Requirements
 This applet requires at least Cinnamon 4.0

--- a/CassiaWindowList@klangman/SetupWizard.ui
+++ b/CassiaWindowList@klangman/SetupWizard.ui
@@ -123,7 +123,7 @@ Panel buttons for all running windows.</property>
                 <child>
                   <object class="GtkRadioButton" id="launcher_radio">
                     <property name="label" translatable="yes">Panel Launcher (Quick launcher)
-Panel button only appear when you add items
+Panel button only appears when you add items
 to the panel, no labels are shown, only icons.</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
@@ -190,7 +190,7 @@ backup</property>
                 <child>
                   <object class="GtkRadioButton" id="one_to_one_radio">
                     <property name="label" translatable="yes">Basic  -  Quick window access
-Every window gets it's own window list button.
+Every window gets its own window list button.
 Button labels are window titles.</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
@@ -234,8 +234,8 @@ Button labels are window titles.</property>
                 <child>
                   <object class="GtkRadioButton" id="pooled_radio">
                     <property name="label" translatable="yes">Pooling  -  Quick access &amp; compact
-Every window gets it's own window list button.
-Application buttons are pooled togeather.
+Every window gets its own window list button.
+Application buttons are pooled together.
 One button label per application pool.
 Button labels are application names.</property>
                     <property name="visible">True</property>
@@ -367,7 +367,7 @@ Button labels are application names.</property>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Unlike most Panel Launcher applets, this launcher keeps tack of 
+                    <property name="label" translatable="yes">Unlike most Panel Launcher applets, this launcher keeps track of 
 running windows and uses window Thumbnail menus.
 
 You can launch additional windows by clicking the 'Back' mouse 
@@ -505,7 +505,7 @@ windows already exist for a launcher button?</property>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">There are many more options and features to explorer in the
+                    <property name="label" translatable="yes">There are many more options and features to explore in the
 applet configurator and the window list button context menu,
 for example:
 

--- a/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
+++ b/CassiaWindowList@klangman/po/CassiaWindowList@klangman.pot
@@ -280,19 +280,19 @@ msgid "What the content of the label will be"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-caption-for->options
-#. 4.0->settings-schema.json->display-caption-for-pined->options
+#. 4.0->settings-schema.json->display-caption-for-pinned->options
 #. 4.0->settings-schema.json->display-number->options
 msgid "Never"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-caption-for->options
-#. 4.0->settings-schema.json->display-caption-for-pined->options
+#. 4.0->settings-schema.json->display-caption-for-pinned->options
 #. 4.0->settings-schema.json->display-number->options
 msgid "Always"
 msgstr ""
 
 #. 4.0->settings-schema.json->display-caption-for->options
-#. 4.0->settings-schema.json->display-caption-for-pined->options
+#. 4.0->settings-schema.json->display-caption-for-pinned->options
 msgid "Focused"
 msgstr ""
 
@@ -313,19 +313,19 @@ msgid ""
 "windows"
 msgstr ""
 
-#. 4.0->settings-schema.json->display-caption-for-pined->options
+#. 4.0->settings-schema.json->display-caption-for-pinned->options
 msgid "Running"
 msgstr ""
 
-#. 4.0->settings-schema.json->display-caption-for-pined->description
+#. 4.0->settings-schema.json->display-caption-for-pinned->description
 msgid "Display labels for pinned buttons"
 msgstr ""
 
-#. 4.0->settings-schema.json->display-caption-for-pined->tooltip
+#. 4.0->settings-schema.json->display-caption-for-pinned->tooltip
 msgid ""
 "Never: No pinned windows will have a label\n"
 "Always: All pinned windows will have labels\n"
-"Running: Only pinned window that are running will have a label\n"
+"Running: Only pinned windows that are running will have a label\n"
 "Focused: Only the pinned window with focus will have a label"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgid ""
 "Pooled: All window list buttons for an application are pooled side by side,\n"
 "Automatic: Windows are pooled, and then grouped when space is limited,\n"
 "One to one: Each window gets their own button with no forced ordering,\n"
-"Launcher: Only pinned button are shown, behaves like a panel launcher."
+"Launcher: Only pinned buttons are shown, behaves like a panel launcher."
 msgstr ""
 
 #. 4.0->settings-schema.json->display-pinned->options
@@ -589,7 +589,7 @@ msgstr ""
 #. 4.0->settings-schema.json->menu-all-windows-of-auto->tooltip
 msgid ""
 "If enabled, a popup menu will contain all the application windows in the "
-"application pool rather then just the selected window within the application "
+"application pool rather than just the selected window within the application "
 "pool"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 #. 4.0->settings-schema.json->hotkey-grave-help->tooltip
 msgid ""
 "If enabled, The hotkey modifier(s) + ` will be registered for each unique "
-"modifier set defined in the hotkey list. Using these hotkeys will temporally "
+"modifier set defined in the hotkey list. Using these hotkeys will temporarily "
 "show a hotkey hint bubble over the button icons."
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid ""
 "Sets the color saturation for icons from 0% (grayscale) to 200%, default is "
 "100%\n"
-"This option is experimental, some icons are not currently effected by this "
+"This option is experimental, some icons are not currently affected by this "
 "setting"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgid "Buttons for windows on other monitors"
 msgstr ""
 
 #. 4.0->settings-schema.json->saturation-application->options
-msgid "All buttons excepted focused window"
+msgid "All buttons except the focused window"
 msgstr ""
 
 #. 4.0->settings-schema.json->saturation-application->description
@@ -1116,7 +1116,7 @@ msgstr ""
 #: SetupWizard.ui:125
 msgid ""
 "Panel Launcher (Quick launcher)\n"
-"Panel button only appear when you add items\n"
+"Panel button only appears when you add items\n"
 "to the panel, no labels are shown, only icons."
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 #: SetupWizard.ui:192
 msgid ""
 "Basic  -  Quick window access\n"
-"Every window gets it's own window list button.\n"
+"Every window gets its own window list button.\n"
 "Button labels are window titles."
 msgstr ""
 
@@ -1148,8 +1148,8 @@ msgstr ""
 #: SetupWizard.ui:236
 msgid ""
 "Pooling  -  Quick access & compact\n"
-"Every window gets it's own window list button.\n"
-"Application buttons are pooled togeather.\n"
+"Every window gets its own window list button.\n"
+"Application buttons are pooled together.\n"
 "One button label per application pool.\n"
 "Button labels are application names."
 msgstr ""
@@ -1176,7 +1176,7 @@ msgstr ""
 
 #: SetupWizard.ui:370
 msgid ""
-"Unlike most Panel Launcher applets, this launcher keeps tack of \n"
+"Unlike most Panel Launcher applets, this launcher keeps track of \n"
 "running windows and uses window Thumbnail menus.\n"
 "\n"
 "You can launch additional windows by clicking the 'Back' mouse \n"
@@ -1208,7 +1208,7 @@ msgstr ""
 
 #: SetupWizard.ui:508
 msgid ""
-"There are many more options and features to explorer in the\n"
+"There are many more options and features to explore in the\n"
 "applet configurator and the window list button context menu,\n"
 "for example:\n"
 "\n"


### PR DESCRIPTION
- Fixed all instances of "pined" → "pinned"
- Corrected misuse of "it's" where possessive "its" was intended
- Fixed several other minor typos